### PR TITLE
New parameter Apartment

### DIFF
--- a/Module/en-US/SplitPipeline.dll-Help.ps1
+++ b/Module/en-US/SplitPipeline.dll-Help.ps1
@@ -155,6 +155,10 @@ Import-Module SplitPipeline
 		Input objects processed by parallel pipelines. Do not use this
 		parameter directly, use the pipeline operator instead.
 '@
+		Apartment = @'
+		Specify either "MTA" or "STA" to use multi- or single-threaded COM
+		apartments in the runspaces.
+'@
 	}
 	inputs = @(
 		@{

--- a/Src/Commands/SplitPipelineCommand.cs
+++ b/Src/Commands/SplitPipelineCommand.cs
@@ -91,6 +91,26 @@ namespace SplitPipeline.Commands
 				}
 			}
 		}
+		[Parameter]
+		[ValidateSet("MTA", "STA")]
+		public string Apartment
+		{
+			set
+			{
+				switch (value.ToUpperInvariant())
+				{
+					case "STA":
+						_iss.ApartmentState = ApartmentState.STA;
+						break;
+					case "MTA":
+						_iss.ApartmentState = ApartmentState.MTA;
+						break;
+					default:
+						_iss.ApartmentState = ApartmentState.Unknown;
+						break;
+				}
+			}
+		}
 		PSObject _Filter;
 		IDictionary _FilterHash;
 		ScriptBlock _FilterScript;


### PR DESCRIPTION
Hi! I'm a big fan of SplitPipeline. I've added a parameter -Apartment, that is optional and accepts
either 'STA' or 'MTA'. Setting this parameter sets the COM threading apartment model on the
runspaces used by the pipeline. I have to set this value when my pipeline includes creating COM
objects, as some COM objects must be used in an STA or MTA environment. Omitting this parameter
keeps the same behavior as before my change, where the runspace uses the 'Unknown' apartment model.

Please let me know if you have any questions. Thanks!

----- Description of change -----

Add an Apartment parameter that sets STA or MTA on the runspace's initial
session state. Setting the apartment threading model is needed to use COM
objects with thread affinity in the pipeline.
